### PR TITLE
Fix historykey construction error in `msgCreateNewChatContext`

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,9 +370,6 @@ async function msgCreateNewChatContext(message) {
   }
   try {
     let historyKey = SHARE_CONTEXT.chatHistoryKey;
-    if (SHARE_CONTEXT.currentBotId) {
-      historyKey += `:${SHARE_CONTEXT.currentBotId}`;
-    }
     await DATABASE.delete(historyKey);
     return sendMessageToTelegram(
         '新的对话已经开始',


### PR DESCRIPTION
见 issue #15 和 https://github.com/TBXark/ChatGPT-Telegram-Workers/issues/15#issuecomment-1455074383