### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can customize the system initialization information so that your debugged pe
 
 - Serverless deployment
 - Multi-platform deployment support (Cloudflare Workers, Vercel, Docker[...](doc/en/PLATFORM.md))
-- Adaptation to multiple AI service providers (OpenAI, Azure OpenAI, Cloudflare AI, Cohere, Anthropic, Mistral, DeepSeek, Gemini, Groq[...](doc/en/CONFIG.md))
+- Adaptation to multiple AI service providers (OpenAI, Azure OpenAI, Cloudflare AI, Cohere, Anthropic, Mistral, DeepSeek, Gemini, Groq, MiniMax[...](doc/en/CONFIG.md))
 - Switching Models with InlineKeyboards
 - Custom commands (can achieve quick switching of models, switching of robot presets)
 - Support for multiple Telegram bots

--- a/doc/cn/CONFIG.md
+++ b/doc/cn/CONFIG.md
@@ -53,7 +53,7 @@
 `LOCK_USER_CONFIG_KEYS`是一个字符串数组，默认值为：
 
 ```
-OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPIC_API_BASE,AZURE_COMPLETIONS_API,AZURE_DALLE_API
+OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPIC_API_BASE,AZURE_COMPLETIONS_API,AZURE_DALLE_API,MINIMAX_API_BASE
 ```
 
 ### 历史记录配置
@@ -86,7 +86,7 @@ OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPI
 
 | KEY                          | 名称              | 默认值      | 描述                                                                     |
 |------------------------------|-----------------|----------|------------------------------------------------------------------------|
-| AI_PROVIDER                  | AI提供商           | `auto`   | 可选值 `auto, openai, azure, workers, gemini, mistral, cohere, anthropic` |
+| AI_PROVIDER                  | AI提供商           | `auto`   | 可选值 `auto, openai, azure, workers, gemini, mistral, cohere, anthropic, deepseek, groq, xai, minimax` |
 | AI_IMAGE_PROVIDER            | AI图片提供商         | `auto`   | 可选值 `auto, openai, azure, workers`                                     |
 | SYSTEM_INIT_MESSAGE          | 全局默认初始化消息       | `null`   | 根据绑定的语言自动选择默认值                                                         |
 | ~~SYSTEM_INIT_MESSAGE_ROLE~~ | ~~全局默认初始化消息角色~~ | `system` | 废弃                                                                     |
@@ -206,6 +206,14 @@ OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPI
 | XAI_CHAT_MODEL       | XAi API Model | `grok-2-latest`    |
 | XAI_CHAT_MODELS_LIST | XAi 聊天模型列表    | `''`               |
 
+### MiniMax
+
+| KEY                      | 名称                | 默认值                                 |
+|--------------------------|-------------------|-------------------------------------|
+| MINIMAX_API_KEY          | MiniMax API Key   | `null`                              |
+| MINIMAX_API_BASE         | MiniMax API Base  | `https://api.minimax.io/v1`         |
+| MINIMAX_CHAT_MODEL       | MiniMax API Model | `MiniMax-M1`                        |
+| MINIMAX_CHAT_MODELS_LIST | MiniMax 聊天模型列表    | `["MiniMax-M1","MiniMax-M1-80k"]`   |
 
 ## 支持命令
 
@@ -312,3 +320,4 @@ console.log(`/setenvs ${stringify(
 | azure     | AZURE_CHAT_MODELS_LIST         | `https://${context.AZURE_RESOURCE_NAME}.openai.azure.com/openai/models?api-version=${context.AZURE_API_VERSION}` |
 | gemini    | GOOGLE_COMPLETIONS_MODELS_LIST | `${GOOGLE_API_BASE}/v1beta/models`                                                                               |
 | anthropic | ANTHROPIC_CHAT_MODELS_LIST     | `${ANTHROPIC_API_BASE}/models`                                                                                   |
+| minimax   | MINIMAX_CHAT_MODELS_LIST       | `${MINIMAX_API_BASE}/models`                                                                                     |

--- a/doc/en/CONFIG.md
+++ b/doc/en/CONFIG.md
@@ -53,7 +53,7 @@ The default value of `LOCK_USER_CONFIG_KEYS` is the BASE URL of all APIs. In ord
 `LOCK_USER_CONFIG_KEYS` is a string array with a default value is 
 
 ```
-OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPIC_API_BASE,AZURE_COMPLETIONS_API,AZURE_DALLE_API
+OPENAI_API_BASE,GOOGLE_COMPLETIONS_API,MISTRAL_API_BASE,COHERE_API_BASE,ANTHROPIC_API_BASE,AZURE_COMPLETIONS_API,AZURE_DALLE_API,MINIMAX_API_BASE
 ```
 
 ### History configuration
@@ -86,7 +86,7 @@ All `xxx_MODELS_LIST` can be a URL or a JSON array string. When it is empty, it 
 
 | KEY                          | Name                                     | Default  | Description                                                                |
 |------------------------------|------------------------------------------|----------|----------------------------------------------------------------------------|
-| AI_PROVIDER                  | AI provider                              | `auto`   | Options `auto, openai, azure, workers, gemini, mistral, cohere, anthropic` |
+| AI_PROVIDER                  | AI provider                              | `auto`   | Options `auto, openai, azure, workers, gemini, mistral, cohere, anthropic, deepseek, groq, xai, minimax` |
 | AI_IMAGE_PROVIDER            | AI image provider                        | `auto`   | Options `auto, openai, azure, workers`                                     |
 | SYSTEM_INIT_MESSAGE          | Default initialization message.          | `null`   | Automatically select default values based on the bound language.           |
 | ~~SYSTEM_INIT_MESSAGE_ROLE~~ | ~~Default initialization message role.~~ | `system` | Deprecated                                                                 |
@@ -199,13 +199,21 @@ All `xxx_MODELS_LIST` can be a URL or a JSON array string. When it is empty, it 
 
 ### XAi
 
-| KEY                  | Name                | Default            | 
+| KEY                  | Name                | Default            |
 |----------------------|---------------------|--------------------|
 | XAI_API_KEY          | XAi API Key         | `null`             |
 | XAI_API_BASE         | XAi API Base        | `https://api.x.ai` |
 | XAI_CHAT_MODEL       | XAi API Model       | `grok-2-latest`    |
 | XAI_CHAT_MODELS_LIST | XAi Chat Model List | `''`               |
 
+### MiniMax
+
+| KEY                      | Name                       | Default                         |
+|--------------------------|----------------------------|---------------------------------|
+| MINIMAX_API_KEY          | MiniMax API Key            | `null`                          |
+| MINIMAX_API_BASE         | MiniMax API Base           | `https://api.minimax.io/v1`     |
+| MINIMAX_CHAT_MODEL       | MiniMax API Model          | `MiniMax-M1`                    |
+| MINIMAX_CHAT_MODELS_LIST | List of MiniMax Chat Models| `["MiniMax-M1","MiniMax-M1-80k"]` |
 
 ## Command
 
@@ -312,3 +320,4 @@ When the model list configuration is empty for an AI provider that supports fetc
 | azure       | AZURE_CHAT_MODELS_LIST         | `https://${context.AZURE_RESOURCE_NAME}.openai.azure.com/openai/models?api-version=${context.AZURE_API_VERSION}` |
 | gemini      | GOOGLE_COMPLETIONS_MODELS_LIST | `${GOOGLE_API_BASE}/v1beta/models`                                                                               |
 | anthropic   | ANTHROPIC_CHAT_MODELS_LIST     | `${ANTHROPIC_API_BASE}/models`                                                                                   |
+| minimax     | MINIMAX_CHAT_MODELS_LIST       | `${MINIMAX_API_BASE}/models`                                                                                     |

--- a/packages/lib/core/src/agent/agent.ts
+++ b/packages/lib/core/src/agent/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentUserConfig } from '#/config';
 import type { ChatAgent, ImageAgent } from './types';
-import { DeepSeek, Groq, Mistral, XAi } from '#/agent/openai_agents';
+import { DeepSeek, Groq, MiniMax, Mistral, XAi } from '#/agent/openai_agents';
 import { Anthropic } from './anthropic';
 import { AzureChatAI, AzureImageAI } from './azure';
 import { Cohere } from './cohere';
@@ -19,6 +19,7 @@ export const CHAT_AGENTS: ChatAgent[] = [
     new DeepSeek(),
     new Groq(),
     new XAi(),
+    new MiniMax(),
 ];
 
 export function loadChatLLM(context: AgentUserConfig): ChatAgent | null {

--- a/packages/lib/core/src/agent/minimax.test.ts
+++ b/packages/lib/core/src/agent/minimax.test.ts
@@ -1,0 +1,337 @@
+import type { AgentUserConfig } from '#/config';
+import type { LLMChatParams } from './types';
+import { CHAT_AGENTS, loadChatLLM } from './agent';
+import { MiniMax } from '#/agent/openai_agents';
+import { ENV } from '#/config';
+import '#/config/env.test';
+
+function createMockConfig(overrides: Partial<AgentUserConfig> = {}): AgentUserConfig {
+    return {
+        ...ENV.USER_CONFIG,
+        ...overrides,
+    } as AgentUserConfig;
+}
+
+describe('MiniMax Agent', () => {
+    describe('registration', () => {
+        it('should be registered in CHAT_AGENTS', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax');
+            expect(minimax).toBeDefined();
+        });
+
+        it('should be an instance of MiniMax', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax');
+            expect(minimax).toBeInstanceOf(MiniMax);
+        });
+    });
+
+    describe('configuration', () => {
+        it('should have correct default config values', () => {
+            const config = ENV.USER_CONFIG;
+            expect(config.MINIMAX_API_KEY).toBeNull();
+            expect(config.MINIMAX_API_BASE).toBe('https://api.minimax.io/v1');
+            expect(config.MINIMAX_CHAT_MODEL).toBe('MiniMax-M1');
+            expect(config.MINIMAX_CHAT_MODELS_LIST).toBe('["MiniMax-M1","MiniMax-M1-80k"]');
+        });
+
+        it('should include MINIMAX_API_BASE in LOCK_USER_CONFIG_KEYS', () => {
+            expect(ENV.LOCK_USER_CONFIG_KEYS).toContain('MINIMAX_API_BASE');
+        });
+    });
+
+    describe('enable', () => {
+        it('should be disabled when API key is null', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({ MINIMAX_API_KEY: null });
+            expect(minimax.enable(config)).toBe(false);
+        });
+
+        it('should be disabled when API key is empty string', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({ MINIMAX_API_KEY: '' });
+            expect(minimax.enable(config)).toBe(false);
+        });
+
+        it('should be enabled when API key is set', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({ MINIMAX_API_KEY: 'test-key' });
+            expect(minimax.enable(config)).toBe(true);
+        });
+    });
+
+    describe('model', () => {
+        it('should return the configured model', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({ MINIMAX_CHAT_MODEL: 'MiniMax-M1-80k' });
+            expect(minimax.model(config)).toBe('MiniMax-M1-80k');
+        });
+
+        it('should return default model when not overridden', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig();
+            expect(minimax.model(config)).toBe('MiniMax-M1');
+        });
+    });
+
+    describe('modelKey', () => {
+        it('should have MINIMAX_CHAT_MODEL as modelKey', () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            expect(minimax.modelKey).toBe('MINIMAX_CHAT_MODEL');
+        });
+    });
+
+    describe('loadChatLLM', () => {
+        it('should load MiniMax agent when AI_PROVIDER is minimax', () => {
+            const config = createMockConfig({
+                AI_PROVIDER: 'minimax',
+            });
+            const agent = loadChatLLM(config);
+            expect(agent).toBeDefined();
+            expect(agent!.name).toBe('minimax');
+        });
+
+        it('should auto-detect MiniMax when API key is set and no other provider keys exist', () => {
+            const config = createMockConfig({
+                AI_PROVIDER: 'auto',
+                OPENAI_API_KEY: [],
+                MINIMAX_API_KEY: 'test-key',
+                ANTHROPIC_API_KEY: null,
+                GOOGLE_API_KEY: null,
+                AZURE_API_KEY: null,
+                CLOUDFLARE_ACCOUNT_ID: null,
+                CLOUDFLARE_TOKEN: null,
+                COHERE_API_KEY: null,
+                MISTRAL_API_KEY: null,
+                DEEPSEEK_API_KEY: null,
+                GROQ_API_KEY: null,
+                XAI_API_KEY: null,
+            });
+            const agent = loadChatLLM(config);
+            expect(agent).toBeDefined();
+            expect(agent!.name).toBe('minimax');
+        });
+    });
+
+    describe('modelList', () => {
+        it('should return static model list from JSON config', async () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({
+                MINIMAX_API_KEY: 'test-key',
+                MINIMAX_CHAT_MODELS_LIST: '["MiniMax-M1","MiniMax-M1-80k"]',
+            });
+            const models = await minimax.modelList(config);
+            expect(models).toEqual(['MiniMax-M1', 'MiniMax-M1-80k']);
+        });
+    });
+
+    describe('request', () => {
+        it('should construct correct request with MiniMax API', async () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({
+                MINIMAX_API_KEY: 'test-key-12345',
+                MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+                MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+            });
+            const params: LLMChatParams = {
+                prompt: 'You are a helpful assistant.',
+                messages: [{ role: 'user', content: 'Hello' }],
+            };
+
+            const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    choices: [{ message: { role: 'assistant', content: 'Hi there!' } }],
+                }), {
+                    headers: { 'content-type': 'application/json' },
+                }),
+            );
+
+            try {
+                const result = await minimax.request(params, config, null);
+                expect(result).toBeDefined();
+                expect(result.text).toBe('Hi there!');
+
+                expect(fetchSpy).toHaveBeenCalledTimes(1);
+                const [url, options] = fetchSpy.mock.calls[0];
+                expect(url).toBe('https://api.minimax.io/v1/chat/completions');
+                expect((options as any).method).toBe('POST');
+
+                const headers = (options as any).headers;
+                expect(headers.Authorization).toBe('Bearer test-key-12345');
+
+                const body = JSON.parse((options as any).body);
+                expect(body.model).toBe('MiniMax-M1');
+                expect(body.stream).toBe(false);
+                expect(body.messages).toHaveLength(2);
+                expect(body.messages[0]).toEqual({ role: 'system', content: 'You are a helpful assistant.' });
+                expect(body.messages[1]).toEqual({ role: 'user', content: 'Hello' });
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+
+        it('should support streaming mode', async () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({
+                MINIMAX_API_KEY: 'test-key',
+                MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+                MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+            });
+            const params: LLMChatParams = {
+                prompt: 'You are a helper.',
+                messages: [{ role: 'user', content: 'Hi' }],
+            };
+
+            const sseData = [
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+                'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+                'data: [DONE]\n\n',
+            ].join('');
+
+            const encoder = new TextEncoder();
+            const stream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(encoder.encode(sseData));
+                    controller.close();
+                },
+            });
+
+            const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+                new Response(stream, {
+                    headers: { 'content-type': 'text/event-stream' },
+                }),
+            );
+
+            try {
+                const chunks: string[] = [];
+                const onStream = async (text: string) => {
+                    chunks.push(text);
+                };
+                const result = await minimax.request(params, config, onStream);
+                expect(result).toBeDefined();
+                expect(result.text).toBe('Hello world');
+
+                const [url, options] = fetchSpy.mock.calls[0];
+                const body = JSON.parse((options as any).body);
+                expect(body.stream).toBe(true);
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+
+        it('should use custom API base when configured', async () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({
+                MINIMAX_API_KEY: 'test-key',
+                MINIMAX_API_BASE: 'https://custom-proxy.example.com/v1',
+                MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+            });
+            const params: LLMChatParams = {
+                prompt: 'Test',
+                messages: [{ role: 'user', content: 'test' }],
+            };
+
+            const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    choices: [{ message: { role: 'assistant', content: 'ok' } }],
+                }), {
+                    headers: { 'content-type': 'application/json' },
+                }),
+            );
+
+            try {
+                await minimax.request(params, config, null);
+                const [url] = fetchSpy.mock.calls[0];
+                expect(url).toBe('https://custom-proxy.example.com/v1/chat/completions');
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+
+        it('should pass extra params when configured', async () => {
+            const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+            const config = createMockConfig({
+                MINIMAX_API_KEY: 'test-key',
+                MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+                MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+                MINIMAX_CHAT_EXTRA_PARAMS: { temperature: 0.7, top_p: 0.9 },
+            });
+            const params: LLMChatParams = {
+                prompt: 'Test',
+                messages: [{ role: 'user', content: 'test' }],
+            };
+
+            const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+                new Response(JSON.stringify({
+                    choices: [{ message: { role: 'assistant', content: 'ok' } }],
+                }), {
+                    headers: { 'content-type': 'application/json' },
+                }),
+            );
+
+            try {
+                await minimax.request(params, config, null);
+                const body = JSON.parse((fetchSpy.mock.calls[0][1] as any).body);
+                expect(body.temperature).toBe(0.7);
+                expect(body.top_p).toBe(0.9);
+            } finally {
+                fetchSpy.mockRestore();
+            }
+        });
+    });
+});
+
+describe('MiniMax Integration Tests', () => {
+    const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+
+    const itIntegration = MINIMAX_API_KEY ? it : it.skip;
+
+    itIntegration('should complete a chat request with MiniMax API', async () => {
+        const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+        const config = createMockConfig({
+            MINIMAX_API_KEY: MINIMAX_API_KEY!,
+            MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+            MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+        });
+        const params: LLMChatParams = {
+            prompt: 'You are a helpful assistant. Reply in one short sentence.',
+            messages: [{ role: 'user', content: 'What is 2+2?' }],
+        };
+
+        const result = await minimax.request(params, config, null);
+        expect(result).toBeDefined();
+        expect(result.text.length).toBeGreaterThan(0);
+        expect(result.responses.length).toBeGreaterThan(0);
+    }, 30000);
+
+    itIntegration('should stream a chat response from MiniMax API', async () => {
+        const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+        const config = createMockConfig({
+            MINIMAX_API_KEY: MINIMAX_API_KEY!,
+            MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+            MINIMAX_CHAT_MODEL: 'MiniMax-M1',
+        });
+        const params: LLMChatParams = {
+            prompt: 'Reply in one word only.',
+            messages: [{ role: 'user', content: 'Say hello' }],
+        };
+
+        const result = await minimax.request(params, config, async (_text) => {
+            // streaming callback
+        });
+        expect(result).toBeDefined();
+        expect(result.text.length).toBeGreaterThan(0);
+    }, 60000);
+
+    itIntegration('should use static model list', async () => {
+        const minimax = CHAT_AGENTS.find(a => a.name === 'minimax')!;
+        const config = createMockConfig({
+            MINIMAX_API_KEY: MINIMAX_API_KEY!,
+            MINIMAX_API_BASE: 'https://api.minimax.io/v1',
+            MINIMAX_CHAT_MODELS_LIST: '["MiniMax-M1","MiniMax-M1-80k"]',
+        });
+        const models = await minimax.modelList(config);
+        expect(models).toBeDefined();
+        expect(Array.isArray(models)).toBe(true);
+        expect(models).toContain('MiniMax-M1');
+    }, 30000);
+});

--- a/packages/lib/core/src/agent/openai_agents.ts
+++ b/packages/lib/core/src/agent/openai_agents.ts
@@ -47,3 +47,15 @@ export class XAi extends OpenAICompatibilityAgent {
         });
     }
 }
+
+export class MiniMax extends OpenAICompatibilityAgent {
+    constructor() {
+        super('minimax', {
+            base: 'MINIMAX_API_BASE',
+            key: 'MINIMAX_API_KEY',
+            model: 'MINIMAX_CHAT_MODEL',
+            modelsList: 'MINIMAX_CHAT_MODELS_LIST',
+            extraParams: 'MINIMAX_CHAT_EXTRA_PARAMS',
+        });
+    }
+}

--- a/packages/lib/core/src/config/config.ts
+++ b/packages/lib/core/src/config/config.ts
@@ -171,7 +171,21 @@ export class XAIConfig {
     XAI_CHAT_EXTRA_PARAMS: Record<string, any> = {};
 }
 
-type UserConfig = AgentShareConfig & OpenAIConfig & DallEConfig & AzureConfig & WorkersConfig & GeminiConfig & MistralConfig & CohereConfig & AnthropicConfig & DeepSeekConfig & GroqConfig & XAIConfig;
+// -- MiniMax 配置 --
+export class MiniMaxConfig {
+    // MiniMax api key
+    MINIMAX_API_KEY: string | null = null;
+    // MiniMax api base
+    MINIMAX_API_BASE = 'https://api.minimax.io/v1';
+    // MiniMax api model
+    MINIMAX_CHAT_MODEL = 'MiniMax-M1';
+    // MiniMax api chat models list
+    MINIMAX_CHAT_MODELS_LIST = '["MiniMax-M1","MiniMax-M1-80k"]';
+    // MiniMax Chat API Extra Params
+    MINIMAX_CHAT_EXTRA_PARAMS: Record<string, any> = {};
+}
+
+type UserConfig = AgentShareConfig & OpenAIConfig & DallEConfig & AzureConfig & WorkersConfig & GeminiConfig & MistralConfig & CohereConfig & AnthropicConfig & DeepSeekConfig & GroqConfig & XAIConfig & MiniMaxConfig;
 export type AgentUserConfigKey = keyof UserConfig;
 
 export class DefineKeys {
@@ -224,6 +238,7 @@ export class EnvironmentConfig {
         'DEEPSEEK_API_BASE',
         'GROQ_API_BASE',
         'XAI_API_BASE',
+        'MINIMAX_API_BASE',
     ];
 
     // -- 群组相关 --

--- a/packages/lib/core/src/config/env.ts
+++ b/packages/lib/core/src/config/env.ts
@@ -2,7 +2,7 @@ import type { I18n } from '#/i18n';
 import type { APIGuardBinding, KVNamespaceBinding, WorkerAIBinding } from './binding';
 import type { AgentUserConfig, AgentUserConfigKey } from './config';
 import { loadI18n } from '#/i18n';
-import { AgentShareConfig, AnthropicConfig, AzureConfig, CohereConfig, DallEConfig, DeepSeekConfig, DefineKeys, EnvironmentConfig, GeminiConfig, GroqConfig, MistralConfig, OpenAIConfig, WorkersConfig, XAIConfig } from './config';
+import { AgentShareConfig, AnthropicConfig, AzureConfig, CohereConfig, DallEConfig, DeepSeekConfig, DefineKeys, EnvironmentConfig, GeminiConfig, GroqConfig, MiniMaxConfig, MistralConfig, OpenAIConfig, WorkersConfig, XAIConfig } from './config';
 import { ConfigMerger } from './merger';
 import { BUILD_TIMESTAMP, BUILD_VERSION } from './version';
 
@@ -28,6 +28,7 @@ function createAgentUserConfig(): AgentUserConfig {
         new DeepSeekConfig(),
         new GroqConfig(),
         new XAIConfig(),
+        new MiniMaxConfig(),
     );
 }
 


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimaxi.com) as a first-class LLM provider, following the existing `OpenAICompatibilityAgent` pattern used by DeepSeek, Groq, Mistral, and XAi.

MiniMax provides high-performance large language models (MiniMax-M1, MiniMax-M1-80k with 80K context window) via an OpenAI-compatible chat completions API at `https://api.minimax.io/v1`.

### Changes

- **Config**: Add `MiniMaxConfig` class with `MINIMAX_API_KEY`, `MINIMAX_API_BASE`, `MINIMAX_CHAT_MODEL`, `MINIMAX_CHAT_MODELS_LIST`, and `MINIMAX_CHAT_EXTRA_PARAMS`
- **Agent**: Add `MiniMax` class extending `OpenAICompatibilityAgent` and register in `CHAT_AGENTS`
- **Security**: Add `MINIMAX_API_BASE` to `LOCK_USER_CONFIG_KEYS` to prevent token leakage
- **Docs**: Update English and Chinese CONFIG.md with MiniMax configuration section and model list table
- **README**: Add MiniMax to the provider list
- **Tests**: 21 tests (18 unit + 3 integration) covering agent registration, config defaults, enable/disable logic, model selection, request construction, streaming, extra params, and live API calls

### Usage

Set `MINIMAX_API_KEY` in environment variables or via `/setenv`, then:
```
/setenv AI_PROVIDER=minimax
```
Or let auto-detection find MiniMax when the API key is configured.

## Test Plan

- [x] All 21 new MiniMax tests pass (18 unit + 3 integration)
- [x] All existing tests pass (no regressions)
- [x] Build succeeds (`pnpm run build:core`)
- [ ] Manual: Set `MINIMAX_API_KEY` and verify chat works via Telegram bot
- [ ] Manual: Use `/models` to switch to MiniMax models

8 files changed, 393 additions, 9 deletions